### PR TITLE
chore(pre-align): align heading structure (3 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,25 +1,33 @@
-## Storage > Storage Gateway > Console User Guide
-## Gateway
-### Create Gateway
+<a id="storage-storage-gateway-console-user-guide"></a>
+## Storage > Storage Gateway > Console User Guide { #storage-storage-gateway-console-user-guide }
+<a id="gateway"></a>
+## Gateway { #gateway }
+<a id="create-gateway"></a>
+### Create Gateway { #create-gateway }
 Create a new storage gateway. The gateway is configured by creating an instance in your project. 
 
+<a id="gateway-information"></a>
 #### Gateway Information
 Set the name, description, and type of storage to connect.
 
 > [Note]
 > As of March 2025, you can connect Object Storage.
 
+<a id="cache-storage"></a>
 #### Cache Storage
 Set the size of storage to use as disk cache for the storage gateway. This is available as an SSD type and can be set to a minimum of 50 GB and a maximum of 2,048 GB.
 
+<a id="network"></a>
 #### Network
 Select a VPC and subnet that you want to use for the storage gateway.
 A network interface is created on the instance that configures the gateway and the interface is associated with the subnet of the selected VPC. For more information about creating and managing network resources, see the [VPC User Guide](/Network/VPC/en/overview/).
 Service gateways are used to connect storage outside of your VPC, such as Object Storage, without going over the Internet. For more information about Service Gateway, see the [Service Gateway User Guide](/Network/Service%20Gateway/en/overview/).
 
+<a id="floating-ip"></a>
 #### Floating IP
 Set whether to use a floating IP. Enabling a floating IP for the gateway allows the gateway to be accessible from the Internet. For more information, see the [Floating IP User Guide](/Network/Floating%20IP/en/overview/).
 
+<a id="security-groups"></a>
 #### Security Groups
 Specify a security group to which the instance of the storage gateway belongs. To mount to NHN Cloud storage through the gateway from outside the selected VPC network, the security group must specify rules for the following ports 
 
@@ -36,35 +44,43 @@ The remote destination IP can be set as a band in CIDR format.
 
 For more information, see the [Security Groups User Guide](/Network/Security%20Groups/en/overview/).
 
+<a id="redundancy"></a>
 #### Redundancy
 Select whether to enable storage gateway redundancy.
 With redundancy enabled, you create two instances to form a cluster. If one instance in the cluster fails, you can use the gateway without interruption through the other instance. The instance that fails and is excluded from the service is automatically recovered by the auto-healing feature and put back into the cluster.
 
-### Start Gateway
+<a id="start-gateway"></a>
+### Start Gateway { #start-gateway }
 Start a stopped storage gateway.
 
-### Stop Gateway 
+<a id="stop-gateway"></a>
+### Stop Gateway { #stop-gateway }
 Stop the storage gateway. When you stop the gateway, the instances that make up the cluster stop and can't connect to storage.
 
 > [Caution]
 > Before stopping the storage gateway, you must unmount the gateway from the system you are using by connecting the NHN Cloud storage. Stopping the gateway while it is mounted may cause problems on your system. 
 
-### Delete Gateway
+<a id="delete-gateway"></a>
+### Delete Gateway { #delete-gateway }
 Delete the storage gateway. All instances and resources that make up the cluster are deleted. NHN Cloud storage that was connected to the gateway is not deleted. 
 
 > [Note]
 > To delete a gateway, you must first delete all shares you created on the gateway.
 
-## Share
-### Create Share
+<a id="share"></a>
+## Share { #share }
+<a id="create-share"></a>
+### Create Share { #create-share }
 Create a share. A share is a setup to connect NHN Cloud storage to. When you create a share, you get the mount connection information, which you can use to mount and use NHN Cloud storage on your system.
 
+<a id="share-information"></a>
 #### Share Information
 Set the share name and protocol to use for the path to the mount connection information.
 
 > [Note]
 > As of March 2025, the NFS protocol is available.
 
+<a id="storage-information-for-connection"></a>
 #### Storage Information for Connection
 Set the information of storage to connect.
 Object Storage requires the name of the container to connect to and the Access Key from your S3 API credentials. The name of the container to connect to must follow Amazon S3's bucket naming conventions. S3 API credentials can be issued using the Object Storage console or API. For more information, see the [Create Bucket](/Storage/Object%20Storage/en/s3-api-guide/#bucket) section and the [S3 API Credentials](/Storage/Object%20Storage/en/s3-api-guide/#s3-api) section of **the Object Storage Amazon S3-compatible API guide**.
@@ -80,6 +96,7 @@ Object Storage requires the name of the container to connect to and the Access K
 > If you delete the container or delete the S3 API credentials while connecting to and using a container in Object Storage through a storage gateway, it can cause problems on your system. You should be careful not to delete them.
 > If you delete objects in the `{container name}+segments` container while connecting to and using a container in Object Storage through a storage gateway, you will not be able to access the files you have stored. Be careful not to delete them.
 
+<a id="nfs-permissions-settings"></a>
 #### NFS Permissions Settings
 Set permissions for clients to connect over the NFS protocol. 
 
@@ -96,37 +113,46 @@ $ id
 uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu)
 ```
 
+<a id="access-control-acl"></a>
 #### Access Control (ACL)
 Enter the IP or IP band of the client that can access NHN Cloud storage through the gateway in CIDR format.
 
+<a id="cache-settings"></a>
 #### Cache Settings
 Set the memory cache validity time. The cache is retained for the set validity time.
 
-### Delete Share
+<a id="delete-share"></a>
+### Delete Share { #delete-share }
 Delete a share. 
 
 > [Caution]
 > Before deleting a share, you must mount the NHN Cloud storage and unmount it from your system. Deleting a share while it is mounted may cause problems on your system. 
 
-### Immediately Empty Cache
+<a id="immediately-empty-cache"></a>
+### Immediately Empty Cache { #immediately-empty-cache }
 Immediately deletes data stored in the disk cache area. 
 
-### Change Access Key
+<a id="change-access-key"></a>
+### Change Access Key { #change-access-key }
 Change the Access Key that you set when creating the share for the Object Storage type gateway.
 
 > [Caution]
 > Before you change the access key, you must mount your NHN Cloud storage and unmount it from your system. Changing the Access Key while mounted may cause problems on your system. 
 
-### Change NFS Permissions
+<a id="change-nfs-permissions"></a>
+### Change NFS Permissions { #change-nfs-permissions }
 Change the permissions of clients to connect over the NFS protocol.
 
-### Change Access Control (ACL)
+<a id="change-access-control-acl"></a>
+### Change Access Control (ACL) { #change-access-control-acl }
 Change the IP or IP band of clients that can access NHN Cloud storage through the gateway.
 
-## Connect NFS
+<a id="connect-nfs"></a>
+## Connect NFS { #connect-nfs }
 To use NFS, you must install the NFS package and run the rpcbind service, as follows
 
-### Install NFS Package
+<a id="install-nfs-package"></a>
+### Install NFS Package { #install-nfs-package }
 * **Debian, Ubuntu**
 ```
 sudo apt-get install nfs-common rpcbind
@@ -137,12 +163,14 @@ sudo apt-get install nfs-common rpcbind
 sudo yum install nfs-utils rpcbind
 ```
 
-### Run rpcbind Service
+<a id="run-rpcbind-service"></a>
+### Run rpcbind Service { #run-rpcbind-service }
 ```
 sudo service rpcbind start
 ```
 
-### Mount Share
+<a id="mount-share"></a>
+### Mount Share { #mount-share }
 Using the mount connection information of the created share and the mount command, you can mount NHN Cloud storage to your system as follows.
 
 ```
@@ -162,10 +190,12 @@ Example: 192.168.0.11:/data
 Example: /mnt/data
 
 
-## POSIX API
+<a id="posix-api"></a>
+## POSIX API { #posix-api }
 Gateways of type Object Storage support only a subset of the POSIX APIs.
 
-### Supported APIs
+<a id="supported-apis"></a>
+### Supported APIs { #supported-apis }
 ```
 read, write, readdir, truncate, fallocate, fsync
 ```

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,40 +1,52 @@
-## Storage > Storage Gateway > Overview
+<a id="storage-storage-gateway-overview"></a>
+## Storage > Storage Gateway > Overview { #storage-storage-gateway-overview }
 
 Storage Gateway allows you to connect NHN Cloud storage from one or more cloud instances or on-premises devices to efficiently store and manage data.
 
 > [Note]
 > Storage Gateway is available in the Korea (Pangyo) region as of March 2025 and can be connected to Object Storage among NHN Cloud storage services.
 
-## Characteristics
-### Sharable
+<a id="characteristics"></a>
+## Characteristics { #characteristics }
+<a id="sharable"></a>
+### Sharable { #sharable }
 You can use NHN Cloud storage by mounting it on one or more instances or on-premises devices.
 The supported protocols are NFS v3, v4 (Linux).
 
-### Convenient
+<a id="convenient"></a>
+### Convenient { #convenient }
 It provides an interface to mount NHN Cloud storage of various interfaces at the file level, so no additional file system configuration or API calls are required.
 
-### Scalable
+<a id="scalable"></a>
+### Scalable { #scalable }
 NHN Cloud storage is highly scalable, giving you the flexibility to grow your storage capacity as your data usage grows.
 
-### Stable
+<a id="stable"></a>
+### Stable { #stable }
 With a redundant configuration, you'll have uninterrupted service in the event of a failure.
 
-### Accessible
+<a id="accessible"></a>
+### Accessible { #accessible }
 You can access NHN Cloud Storage from different environments by connecting a floating IP to the VPC network on the gateway or by setting up a network gateway.
 
-### Secure
+<a id="secure"></a>
+### Secure { #secure }
 NHN Cloud storage utilizes server-side encryption to keep your data secure.
 
-### Disaster Recovery
+<a id="disaster-recovery"></a>
+### Disaster Recovery { #disaster-recovery }
 Disaster recovery settings in NHN Cloud Storage help you prepare for unexpected disasters.
 
 
-## Terms
-### Gateway
+<a id="terms"></a>
+## Terms { #terms }
+<a id="gateway"></a>
+### Gateway { #gateway }
 A cluster of instances that provides an interface to connect to NHN Cloud storage.
 The gateway is created in a user project and can be configured for redundancy.
 
-### Share
+<a id="share"></a>
+### Share { #share }
 A setting to connect NHN Cloud storage.
 You can set storage information, protocols, access permissions, ACLs, and more to connect.
 

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,5 +1,7 @@
-## Storage > Storage Gateway > Release Notes
+<a id="storage-storage-gateway-release-notes"></a>
+## Storage > Storage Gateway > Release Notes { #storage-storage-gateway-release-notes }
 
-### March 4, 2025
+<a id="march-4-2025"></a>
+### March 4, 2025 { #march-4-2025 }
 * Release of a New Service
     * Storage Gateway is now available. Available in the Korea (Pangyo) region.

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,25 +1,33 @@
-## Storage > Storage Gateway > コンソール使用ガイド
-## ゲートウェイ(Gateway)
-### ゲートウェイ作成
+<a id="storage-storage-gateway-console-user-guide"></a>
+## Storage > Storage Gateway > コンソール使用ガイド { #storage-storage-gateway-console-user-guide }
+<a id="gateway"></a>
+## ゲートウェイ(Gateway) { #gateway }
+<a id="create-gateway"></a>
+### ゲートウェイ作成 { #create-gateway }
 新しいストレージゲートウェイを作成します。ゲートウェイはユーザープロジェクトにインスタンスを作成して構成します。 
 
+<a id="gateway-information"></a>
 #### ゲートウェイ情報
 ストレージゲートウェイの名前、説明、接続するストレージタイプを設定します。
 
 > [参考]
 > 2025年3月現在、Object Storageを接続できます。
 
+<a id="cache-storage"></a>
 #### キャッシュストレージ
 ストレージゲートウェイのディスクキャッシュとして使用するストレージのサイズを設定します。SSDタイプで提供され、最小50GB、最大2,048GBまで設定できます。
 
+<a id="network"></a>
 #### ネットワーク
 ストレージゲートウェイに使用するVPCとサブネットを選択します。 
 ゲートウェイを構成するインスタンスに選択したVPCのサブネットと接続されるネットワークインターフェイスが作成されます。ネットワークリソースの作成と管理の詳細については[VPCユーザーガイド](/Network/VPC/ko/overview/)を参照してください。
 サービスゲートウェイはObject Storageのように、ユーザーVPC外部のストレージをインターネットを経由せずに接続するために使用します。サービスゲートウェイの詳細については[Service Gateway使用ガイド](/Network/Service%20Gateway/ko/overview/)を参照してください。
 
+<a id="floating-ip"></a>
 #### Floating IP
 Floating IPを使用するかどうかを設定します。ゲートウェイにFloating IPを使用すると、インターネットからゲートウェイに接続できます。詳細は、[Floating IP使用ガイド](/Network/Floating%20IP/ko/overview/)を参照してください。
 
+<a id="security-groups"></a>
 #### セキュリティグループ
 ストレージゲートウェイのインスタンスが属するセキュリティグループを指定します。選択したVPCネットワーク外部からゲートウェイを経由してNHN Cloudストレージにマウントするには、セキュリティグループに次のようなポートについてのルールが明示されている必要があります。
 
@@ -36,35 +44,43 @@ Floating IPを使用するかどうかを設定します。ゲートウェイに
 
 詳細は[Security Groups使用ガイド](/Network/Security%20Groups/ko/overview/)を参照してください。
 
+<a id="redundancy"></a>
 #### 冗長化
 ストレージゲートウェイを冗長化するかどうかを選択します。
 冗長化を使用すると、2つのインスタンスを作成してクラスターを構成します。クラスターを構成する1つのインスタンスに障害が発生しても、他のインスタンスを介して中断することなくゲートウェイを使用できます。障害が発生してサービスから除外されたインスタンスは、オートヒーリング機能により自動的に復旧され、クラスターに投入されます。
 
-### ゲートウェイ開始
+<a id="start-gateway"></a>
+### ゲートウェイ開始 { #start-gateway }
 停止していたストレージゲートウェイを開始します。
 
-### ゲートウェイ停止
+<a id="stop-gateway"></a>
+### ゲートウェイ停止 { #stop-gateway }
 ストレージゲートウェイを停止します。ゲートウェイを停止すると、クラスターを構成するインスタンスが停止し、ストレージと接続できません。
 
 > [注意]
 > ストレージゲートウェイを停止する前に、NHN Cloudストレージを接続して使用中のシステムからアンマウントする必要があります。マウント状態でゲートウェイを停止すると、ユーザーシステムに問題が発生する可能性があります。
 
-### ゲートウェイ削除
+<a id="delete-gateway"></a>
+### ゲートウェイ削除 { #delete-gateway }
 ストレージゲートウェイを削除します。クラスターを構成する全てのインスタンスとリソースが削除されます。ゲートウェイに接続されていたNHN Cloudストレージは削除されません。
 
 > [参考]
 > ゲートウェイを削除するには、まず、ゲートウェイに作成した全ての共有を削除する必要があります。
 
-## 共有(Share)
-### 共有作成
+<a id="share"></a>
+## 共有(Share) { #share }
+<a id="create-share"></a>
+### 共有作成 { #create-share }
 共有を作成します。共有はNHN Cloudストレージを接続する設定です。共有を作成すると、マウント接続情報を取得することができ、この接続情報を利用してユーザーシステムにNHN Cloudストレージをマウントして使用できます。
 
+<a id="share-information"></a>
 #### 共有情報
 マウント接続情報のパスに使用する共有名とプロトコルを設定します。
 
 > [参考]
 > 2025年3月現在、NFSプロトコルを使用できます。
 
+<a id="storage-information-for-connection"></a>
 #### 接続ストレージ情報
 接続するストレージ情報を設定します。 
 Object Storageは接続するコンテナ名とS3 API認証情報のAccess Keyが必要です。接続するコンテナ名はAmazon S3のバケット命名規則に従わなければなりません。S3 API認証情報はObject StorageコンソールまたはAPIを利用して発行できます。詳細は**Object Storage Amazon S3互換APIガイド**の[バケット作成](/Storage/Object%20Storage/ko/s3-api-guide/#bucket)セクションと[S3 API認証情報](/Storage/Object%20Storage/ko/s3-api-guide/#s3-api)セクションを参照してください。
@@ -80,6 +96,7 @@ Object Storageは接続するコンテナ名とS3 API認証情報のAccess Key�
 > ストレージゲートウェイを介してObject Storageのコンテナを接続して使用している間にコンテナを削除したり、S3 API認証情報を削除すると、ユーザーシステムに問題が発生する可能性があります。削除しないように注意してください。
 > ストレージゲートウェイを介してObject Storageのコンテナを接続して使用している間に`{コンテナ名}+segments`コンテナのオブジェクトを削除すると、保存したファイルにアクセスできなくなります。削除しないように注意してください。
 
+<a id="nfs-permissions-settings"></a>
 #### NFS権限設定
 NFSプロトコルで接続するクライアントの権限を設定します。 
 
@@ -96,37 +113,46 @@ $ id
 uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu)
 ```
 
+<a id="access-control-acl"></a>
 #### アクセス制御(ACL)
 ゲートウェイを介してNHN CloudストレージにアクセスできるクライアントのIPまたはIP帯域をCIDR形式で入力します。
 
+<a id="cache-settings"></a>
 #### キャッシュ設定
 メモリキャッシュの有効時間を設定します。設定された有効時間の間、キャッシュが維持されます。
 
-### 共有削除
+<a id="delete-share"></a>
+### 共有削除 { #delete-share }
 共有を削除します。 
 
 > [注意]
 > 共有を削除する前に、NHN Cloudストレージをマウントして使用しているシステムからアンマウントする必要があります。マウントした状態で共有を削除すると、ユーザーシステムに問題が発生する可能性があります。
 
-### キャッシュをすぐに空にする
+<a id="immediately-empty-cache"></a>
+### キャッシュをすぐに空にする { #immediately-empty-cache }
 ディスクキャッシュ領域に保存されているデータを直ちに削除します。
 
-### Access Key変更
+<a id="change-access-key"></a>
+### Access Key変更 { #change-access-key }
 Object Storageタイプゲートウェイの共有作成時に設定したAccess Keyを変更します。
 
 > [注意]
 > Access Keyを変更する前に、NHN Cloudストレージをマウントして使用中のシステムからアンマウントする必要があります。マウントした状態でAccess Keyを変更すると、ユーザーシステムに問題が発生する可能性があります。
 
-### NFS権限変更
+<a id="change-nfs-permissions"></a>
+### NFS権限変更 { #change-nfs-permissions }
 NFSプロトコルで接続するクライアントの権限を変更します。
 
-### アクセス制御(ACL)変更
+<a id="change-access-control-acl"></a>
+### アクセス制御(ACL)変更 { #change-access-control-acl }
 ゲートウェイを介してNHN CloudストレージにアクセスできるクライアントのIPまたはIP帯域を変更します。
 
-## NFS接続
+<a id="connect-nfs"></a>
+## NFS接続 { #connect-nfs }
 NFSを使用するには、次のようにNFSパッケージをインストールし、rpcbindサービスを実行する必要があります。
 
-### NFSパッケージインストール
+<a id="install-nfs-package"></a>
+### NFSパッケージインストール { #install-nfs-package }
 * **Debian, Ubuntu**
 ```
 sudo apt-get install nfs-common rpcbind
@@ -137,12 +163,14 @@ sudo apt-get install nfs-common rpcbind
 sudo yum install nfs-utils rpcbind
 ```
 
-### rpcbindサービス実行
+<a id="run-rpcbind-service"></a>
+### rpcbindサービス実行 { #run-rpcbind-service }
 ```
 sudo service rpcbind start
 ```
 
-### 共有マウント
+<a id="mount-share"></a>
+### 共有マウント { #mount-share }
 作成した共有のマウント接続情報とmountコマンドを利用して次のようにNHN Cloudストレージをユーザーシステムにマウントできます。
 
 ```
@@ -162,10 +190,12 @@ sudo mount -t nfs -o vers=3 {マウント接続情報} {マウントするパス
  例：/mnt/data
 
 
-## POSIX API
+<a id="posix-api"></a>
+## POSIX API { #posix-api }
 Object StorageタイプのゲートウェイはPOSIX APIの一部のみサポートします。
 
-### サポートするAPI
+<a id="supported-apis"></a>
+### サポートするAPI { #supported-apis }
 ```
 read, write, readdir, truncate, fallocate, fsync
 ```

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,39 +1,51 @@
-## Storage > Storage Gateway > 概要
+<a id="storage-storage-gateway-overview"></a>
+## Storage > Storage Gateway > 概要 { #storage-storage-gateway-overview }
 
 Storage Gatewayは、1つ以上のクラウドインスタンスまたはオンプレミス機器からNHN Cloudストレージを接続し、データを効率的に保存・管理できるサービスです。
 
 > [参考]
 > Storage Gatewayは、2025年3月現在、韓国(パンギョ)リージョンで提供されており、NHN Cloudストレージサービスのうち、Object Storageと接続できます。
 
-## 特徴
-### 共有
+<a id="characteristics"></a>
+## 特徴 { #characteristics }
+<a id="sharable"></a>
+### 共有 { #sharable }
 NHN Cloudストレージを1つ以上のインスタンスまたはオンプレミス機器にマウントして使用できます。
 サポートするプロトコルはNFS v3、v4(Linux)です。
 
-### 利便性
+<a id="convenient"></a>
+### 利便性 { #convenient }
 様々なインターフェイスのNHN Cloudストレージをファイルレベルでマウントできるインターフェイスを提供するため、別途のファイルシステム構成やAPI呼び出しが必要ありません。
 
-### 拡張性
+<a id="scalable"></a>
+### 拡張性 { #scalable }
 NHN Cloudストレージの優れた拡張性により、データ使用量に応じてストレージ容量を柔軟に増設できます。
 
-### 安定性
+<a id="stable"></a>
+### 安定性 { #stable }
 冗長化構成により、障害が発生してもサービスを中断することなく使用できます。
 
-### アクセシビリティ
+<a id="accessible"></a>
+### アクセシビリティ { #accessible }
 ゲートウェイのVPCネットワークにFloating IPを接続したり、ネットワークゲートウェイ設定により、多様な環境でNHN Cloud Storageにアクセスできます。
 
-### セキュリティ性
+<a id="secure"></a>
+### セキュリティ性 { #secure }
 NHN Cloudストレージのサーバー側暗号化機能を利用して、データを安全に保管できます。
 
-### 災害復旧
+<a id="disaster-recovery"></a>
+### 災害復旧 { #disaster-recovery }
 NHN Cloudストレージの災害復旧設定により、予期せぬ災害状況に備えることができます。
 
 
-## 用語
-### ゲートウェイ
+<a id="terms"></a>
+## 用語 { #terms }
+<a id="gateway"></a>
+### ゲートウェイ { #gateway }
 NHN Cloudストレージに接続するインターフェイスを提供するインスタンスクラスターです。
 ユーザープロジェクトに作成され、冗長化構成が可能です。
 
-### 共有
+<a id="share"></a>
+### 共有 { #share }
 NHN Cloudストレージを接続する設定です。
 接続するストレージ情報、プロトコル、アクセス権限、ACLなどを設定できます。

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,5 +1,7 @@
-## Storage > Storage Gateway > リリースノート
+<a id="storage-storage-gateway-release-notes"></a>
+## Storage > Storage Gateway > リリースノート { #storage-storage-gateway-release-notes }
 
-### 2025. 03. 04.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
 * 新規サービスリリース
     * Storage Gatewayサービスをリリースしました。韓国(パンギョ)リージョンで提供します。

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,25 +1,33 @@
-## Storage > Storage Gateway > 콘솔 사용 가이드
-## 게이트웨이(Gateway)
-### 게이트웨이 생성
+<a id="storage-storage-gateway-console-user-guide"></a>
+## Storage > Storage Gateway > 콘솔 사용 가이드 { #storage-storage-gateway-console-user-guide }
+<a id="gateway"></a>
+## 게이트웨이(Gateway) { #gateway }
+<a id="create-gateway"></a>
+### 게이트웨이 생성 { #create-gateway }
 새로운 스토리지 게이트웨이를 생성합니다. 게이트웨이는 사용자 프로젝트에 인스턴스를 생성해 구성합니다. 
 
+<a id="gateway-information"></a>
 #### 게이트웨이 정보
 스토리지 게이트웨이의 이름, 설명, 연결할 스토리지 유형을 설정합니다.
 
 > [참고]
 > 2025년 3월 현재 Object Storage를 연결할 수 있습니다.
 
+<a id="cache-storage"></a>
 #### 캐시 스토리지
 스토리지 게이트웨이의 디스크 캐시로 사용할 스토리지의 크기를 설정합니다. SSD 타입으로 제공되며 최소 50GB, 최대 2,048GB까지 설정할 수 있습니다.
 
+<a id="network"></a>
 #### 네트워크
 스토리지 게이트웨이에 사용할 VPC와 서브넷을 선택합니다. 
 게이트웨이를 구성하는 인스턴스에 선택한 VPC의 서브넷과 연결되는 네트워크 인터페이스가 만들어집니다. 네트워크 자원의 생성과 관리에 대한 자세한 내용은 [VPC 사용자 가이드](/Network/VPC/ko/overview/)를 참조하세요.
 서비스 게이트웨이는 Object Storage와 같이 사용자 VPC 외부의 스토리지를 인터넷 경유 없이 연결하기 위해 사용합니다. 서비스 게이트웨이에 대한 자세한 내용은 [Service Gateway 사용 가이드](/Network/Service%20Gateway/ko/overview/)를 참조하세요.
 
+<a id="floating-ip"></a>
 #### 플로팅 IP
 플로팅 IP 사용 여부를 설정합니다. 게이트웨이에 플로팅 IP를 사용하면 인터넷에서 게이트웨이에 접속할 수 있습니다. 자세한 내용은 [Floating IP 사용 가이드](/Network/Floating%20IP/ko/overview/)를 참조하세요.
 
+<a id="security-groups"></a>
 #### 보안 그룹
 스토리지 게이트웨이의 인스턴스가 속할 보안 그룹을 지정합니다. 선택한 VPC 네트워크 외부에서 게이트웨이를 통해 NHN Cloud 스토리지에 마운트하려면 보안 그룹에 다음과 같은 포트에 대한 규칙이 명시되어 있어야 합니다. 
 
@@ -36,35 +44,43 @@
 
 자세한 내용은 [Security Groups 사용 가이드](/Network/Security%20Groups/ko/overview/)를 참조하세요.
 
+<a id="redundancy"></a>
 #### 이중화
 스토리지 게이트웨이 이중화 여부를 선택합니다. 
 이중화를 사용하면 2개의 인스턴스를 생성해 클러스터를 구성합니다. 클러스터를 구성하는 하나의 인스턴스에 장애가 발생하더라도 다른 인스턴스를 통해 중단 없이 게이트웨이를 사용할 수 있습니다. 장애가 발생하여 서비스에서 제외된 인스턴스는 오토 힐링 기능을 통해 자동으로 복구되어 클러스터에 투입됩니다.
 
-### 게이트웨이 시작
+<a id="start-gateway"></a>
+### 게이트웨이 시작 { #start-gateway }
 중지된 스토리지 게이트웨이를 시작합니다.
 
-### 게이트웨이 중지 
+<a id="stop-gateway"></a>
+### 게이트웨이 중지 { #stop-gateway }
 스토리지 게이트웨이를 중지합니다. 게이트웨이를 중지하면 클러스터를 구성하는 인스턴스가 중지되며 스토리지와 연결할 수 없습니다.
 
 > [주의]
 > 스토리지 게이트웨이를 중지하기 전, NHN Cloud 스토리지를 연결하여 사용 중인 시스템에서 언마운트해야 합니다. 마운트 상태에서 게이트웨이를 중지하면 사용자 시스템에 문제가 발생할 수 있습니다. 
 
-### 게이트웨이 삭제
+<a id="delete-gateway"></a>
+### 게이트웨이 삭제 { #delete-gateway }
 스토리지 게이트웨이를 삭제합니다. 클러스터를 구성하는 모든 인스턴스와 자원이 삭제됩니다. 게이트웨이에 연결되어 있던 NHN Cloud 스토리지는 삭제되지 않습니다. 
 
 > [참고]
 > 게이트웨이를 삭제하려면 먼저 게이트웨이에 생성한 모든 공유를 삭제해야 합니다.
 
-## 공유(Share)
-### 공유 생성
+<a id="share"></a>
+## 공유(Share) { #share }
+<a id="create-share"></a>
+### 공유 생성 { #create-share }
 공유를 생성합니다. 공유는 NHN Cloud 스토리지를 연결할 설정입니다. 공유를 생성하면 마운트 연결 정보를 얻을 수 있고, 이 연결 정보를 이용해 사용자 시스템에 NHN Cloud 스토리지를 마운트하여 사용할 수 있습니다.
 
+<a id="share-information"></a>
 #### 공유 정보
 마운트 연결 정보의 경로에 사용할 공유 이름과 프로토콜을 설정합니다.
 
 > [참고]
 > 2025년 3월 현재 NFS 프로토콜을 사용할 수 있습니다.
 
+<a id="storage-information-for-connection"></a>
 #### 연결 스토리지 정보
 연결할 스토리지 정보를 설정합니다. 
 Object Storage는 연결할 컨테이너 이름과 S3 API 자격 증명의 Access Key가 필요합니다. 연결할 컨테이너의 이름은 Amazon S3의 버킷 명명 규칙을 따라야 합니다. S3 API 자격 증명은 Object Storage 콘솔 또는 API를 이용해 발급할 수 있습니다. 자세한 내용은 **Object Storage Amazon S3 호환 API 가이드**의 [버킷 생성](/Storage/Object%20Storage/ko/s3-api-guide/#bucket) 섹션과 [S3 API 자격 증명](/Storage/Object%20Storage/ko/s3-api-guide/#s3-api) 섹션을 참조하세요.
@@ -80,6 +96,7 @@ Object Storage는 연결할 컨테이너 이름과 S3 API 자격 증명의 Acces
 > 스토리지 게이트웨이를 통해 Object Storage의 컨테이너를 연결해 사용하는 동안 컨테이너를 삭제하거나 S3 API 자격 증명을 삭제한다면 사용자 시스템에 문제가 생길 수 있습니다. 삭제하지 않도록 주의해야 합니다.
 > 스토리지 게이트웨이를 통해 Object Storage의 컨테이너를 연결해 사용하는 동안 `{컨테이너명}+segments` 컨테이너의 오브젝트를 삭제하면 저장한 파일에 접근할 수 없습니다. 삭제하지 않도록 주의해야 합니다.
 
+<a id="nfs-permissions-settings"></a>
 #### NFS 권한 설정
 NFS 프로토콜을 통해 연결할 클라이언트의 권한을 설정합니다. 
 
@@ -96,37 +113,46 @@ $ id
 uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu)
 ```
 
+<a id="access-control-acl"></a>
 #### 접근 제어(ACL)
 게이트웨이를 통해 NHN Cloud 스토리지에 접근할 수 있는 클라이언트의 IP 또는 IP 대역을 CIDR 형식으로 입력합니다.
 
+<a id="cache-settings"></a>
 #### 캐시 설정
 메모리 캐시 유효 시간을 설정합니다. 설정된 유효 시간 동안 캐시가 유지됩니다.
 
-### 공유 삭제
+<a id="delete-share"></a>
+### 공유 삭제 { #delete-share }
 공유를 삭제합니다. 
 
 > [주의]
 > 공유를 삭제하기 전에 NHN Cloud 스토리지를 마운트하여 사용 중인 시스템에서 언마운트해야 합니다. 마운트 상태에서 공유를 삭제하면 사용자 시스템에 문제가 생길 수 있습니다. 
 
-### 캐시 즉시 비우기
+<a id="immediately-empty-cache"></a>
+### 캐시 즉시 비우기 { #immediately-empty-cache }
 디스크 캐시 영역에 저장된 데이터를 즉시 삭제합니다. 
 
-### Access Key 변경
+<a id="change-access-key"></a>
+### Access Key 변경 { #change-access-key }
 Object Storage 유형 게이트웨이의 공유 생성 시 설정한 Access Key를 변경합니다.
 
 > [주의]
 > Access Key를 변경하기 전에 NHN Cloud 스토리지를 마운트하여 사용 중인 시스템에서 언마운트해야 합니다. 마운트 상태에서 Access Key를 변경하면 사용자 시스템에 문제가 생길 수 있습니다. 
 
-### NFS 권한 변경
+<a id="change-nfs-permissions"></a>
+### NFS 권한 변경 { #change-nfs-permissions }
 NFS 프로토콜을 통해 연결할 클라이언트의 권한을 변경합니다.
 
-### 접근 제어(ACL) 변경
+<a id="change-access-control-acl"></a>
+### 접근 제어(ACL) 변경 { #change-access-control-acl }
 게이트웨이를 통해 NHN Cloud 스토리지에 접근할 수 있는 클라이언트의 IP 또는 IP 대역을 변경합니다.
 
-## NFS 연결
+<a id="connect-nfs"></a>
+## NFS 연결 { #connect-nfs }
 NFS를 사용하려면 다음과 같이 NFS 패키지를 설치하고 rpcbind 서비스를 실행해야 합니다.
 
-### NFS 패키지 설치
+<a id="install-nfs-package"></a>
+### NFS 패키지 설치 { #install-nfs-package }
 * **Debian, Ubuntu**
 ```
 sudo apt-get install nfs-common rpcbind
@@ -137,12 +163,14 @@ sudo apt-get install nfs-common rpcbind
 sudo yum install nfs-utils rpcbind
 ```
 
-### rpcbind 서비스 실행
+<a id="run-rpcbind-service"></a>
+### rpcbind 서비스 실행 { #run-rpcbind-service }
 ```
 sudo service rpcbind start
 ```
 
-### 공유 마운트
+<a id="mount-share"></a>
+### 공유 마운트 { #mount-share }
 생성한 공유의 마운트 연결 정보와 mount 명령을 이용하여 다음과 같이 NHN Cloud 스토리지를 사용자 시스템에 마운트할 수 있습니다.
 
 ```
@@ -162,10 +190,12 @@ sudo mount -t nfs -o vers=3 {마운트 연결 정보} {마운트할 경로}
   예: /mnt/data
 
 
-## POSIX API
+<a id="posix-api"></a>
+## POSIX API { #posix-api }
 Object Storage 유형의 게이트웨이는 POSIX API 일부만 지원합니다.
 
-### 지원하는 API
+<a id="supported-apis"></a>
+### 지원하는 API { #supported-apis }
 ```
 read, write, readdir, truncate, fallocate, fsync
 ```

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,40 +1,52 @@
-## Storage > Storage Gateway > 개요
+<a id="storage-storage-gateway-overview"></a>
+## Storage > Storage Gateway > 개요 { #storage-storage-gateway-overview }
 
 Storage Gateway는 하나 이상의 클라우드 인스턴스 또는 온프레미스 장비에서 NHN Cloud 스토리지를 연결하여 데이터를 효율적으로 저장하고 관리할 수 있는 서비스입니다.
 
 > [참고]
 > Storage Gateway는 2025년 3월 기준 한국(판교) 리전에서 제공되며, NHN Cloud 스토리지 서비스 중 Object Storage와 연결할 수 있습니다.
 
-## 특징
-### 공유
+<a id="characteristics"></a>
+## 특징 { #characteristics }
+<a id="sharable"></a>
+### 공유 { #sharable }
 NHN Cloud 스토리지를 하나 이상의 인스턴스 또는 온프레미스 장비에 마운트하여 사용할 수 있습니다.
 지원하는 프로토콜은 NFS v3, v4(Linux)입니다.
 
-### 편리성
+<a id="convenient"></a>
+### 편리성 { #convenient }
 다양한 인터페이스의 NHN Cloud 스토리지를 파일 수준으로 마운트할 수 있는 인터페이스를 제공하기 때문에 별도의 파일 시스템 구성이나 API 호출이 필요하지 않습니다.
 
-### 확장성
+<a id="scalable"></a>
+### 확장성 { #scalable }
 NHN Cloud 스토리지의 뛰어난 확장성을 통해 데이터 사용량에 따라 스토리지 용량을 유연하게 증설할 수 있습니다.
 
-### 안정성
+<a id="stable"></a>
+### 안정성 { #stable }
 이중화 구성을 통해, 장애가 발생하더라도 서비스 중단 없이 사용할 수 있습니다.
 
-### 접근성
+<a id="accessible"></a>
+### 접근성 { #accessible }
 게이트웨이의 VPC 네트워크에 Floating IP를 연결하거나 네트워크 게이트웨이 설정을 통해 다양한 환경에서 NHN Cloud Storage에 접근할 수 있습니다.
 
-### 보안성
+<a id="secure"></a>
+### 보안성 { #secure }
 NHN Cloud 스토리지의 서버 측 암호화 기능을 이용하여 데이터를 안전하게 보관할 수 있습니다.
 
-### 재해 복구
+<a id="disaster-recovery"></a>
+### 재해 복구 { #disaster-recovery }
 NHN Cloud 스토리지의 재해 복구 설정을 통해 예기치 않은 재해 상황에 대비할 수 있습니다.
 
 
-## 용어
-### 게이트웨이
+<a id="terms"></a>
+## 용어 { #terms }
+<a id="gateway"></a>
+### 게이트웨이 { #gateway }
 NHN Cloud 스토리지에 연결할 인터페이스를 제공하는 인스턴스 클러스터입니다.
 사용자 프로젝트에 생성되며 이중화 구성을 할 수 있습니다.
 
-### 공유
+<a id="share"></a>
+### 공유 { #share }
 NHN Cloud 스토리지를 연결할 설정입니다.
 연결할 스토리지 정보, 프로토콜, 접근 권한, ACL 등을 설정할 수 있습니다.
 

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,5 +1,7 @@
-## Storage > Storage Gateway > 릴리스 노트
+<a id="storage-storage-gateway-release-notes"></a>
+## Storage > Storage Gateway > 릴리스 노트 { #storage-storage-gateway-release-notes }
 
-### 2025. 03. 04.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
 * 신규 서비스 출시
     * Storage Gateway 서비스가 출시되었습니다. 한국(판교) 리전에서 제공합니다.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 3 doc(s) scanned · 9 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/53/ |
| Generated | 2026-07-08T08:24:25 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FStorage-Storage-Gateway%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FStorage-Storage-Gateway%2Fpull%2F8&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FStorage-Storage-Gateway%2Fpull%2F8&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Storage-Storage-Gateway`